### PR TITLE
Revert "IDEA: New Healtask"

### DIFF
--- a/SabberStoneCore/Tasks/SimpleTasks/HealTask.cs
+++ b/SabberStoneCore/Tasks/SimpleTasks/HealTask.cs
@@ -8,76 +8,27 @@ namespace SabberStoneCore.Tasks.SimpleTasks
         {
             Amount = amount;
             Type = entityType;
-            Sort = HealType.Heal;
-        }
-
-        public HealTask(EntityType entityType)
-        {
-            Type = entityType;
-            Sort = HealType.HealNumber;
-        }
-        
-        public HealTask(int amount)
-        {
-            Amount = amount;
-            Type = EntityType.STACK;
-            Sort = HealType.HealStack;
         }
 
         public int Amount { get; set; }
 
         public EntityType Type { get; set; }
 
-        internal HealType Sort { get; set; }
-
-        internal enum HealType
-        {
-            Heal, HealNumber, HealStack 
-        }
-
         public override TaskState Process()
         {
+            if (Amount < 1)
+            {
+                return TaskState.STOP;
+            }
+
             var source = Source as IPlayable;
             var entities = IncludeTask.GetEntites(Type, Controller, Source, Target, Playables);
-            switch (Sort)
+            entities.ForEach(p =>
             {
-                case HealType.Heal:
-                    if (Amount < 1)
-                    {
-                        return TaskState.STOP;
-                    }
+                var target = p as ICharacter;
+                target?.TakeHeal(source, Amount);
+            });
 
-                    entities.ForEach(p =>
-                    {
-                        var target = p as ICharacter;
-                        target?.TakeHeal(source, Amount);
-                    });
-                    break;
-
-                case HealType.HealNumber:
-                    entities.ForEach(p =>
-                    {
-                        var target = p as ICharacter;
-                        target?.TakeHeal(source, Number);
-                    });
-                    break;
-
-                case HealType.HealStack:
-                    if ((source == null) || (Amount < 1))
-                    {
-                        return TaskState.STOP;
-                    }
-
-                    Playables.ForEach(p =>
-                    {
-                        var target = p as ICharacter;
-                        target?.TakeHeal(source, Amount);
-                    });
-                    break;
-
-                default:
-                    break;
-            }
             return TaskState.COMPLETE;
         }
 

--- a/SabberStoneCoreConsole/Program.cs
+++ b/SabberStoneCoreConsole/Program.cs
@@ -398,19 +398,38 @@ namespace SabberStoneCoreConsole
             var game = new Game(new GameConfig
             {
                 StartPlayer = 1,
-                Player1HeroClass = CardClass.PALADIN,
-                Player2HeroClass = CardClass.PALADIN,
-                FillDecks = true
+                Player1HeroClass = CardClass.HUNTER,
+                DeckPlayer1 = new List<Card>
+                {
+                    Cards.FromName("Loot Hoarder"),
+                },
+                Player2HeroClass = CardClass.WARRIOR,
+                DeckPlayer2 = new List<Card>
+                {
+                    Cards.FromName("Whirlwind"),
+                    Cards.FromName("Brawl"),
+                    Cards.FromName("Shieldbearer"),
+                    Cards.FromName("Public Defender"),
+                    Cards.FromName("Battle Rage"),
+                    Cards.FromName("Public Defender"),
+                    Cards.FromName("Armorsmith"),
+                    Cards.FromName("Armorsmith"),
+                    Cards.FromName("Acolyte of Pain"),
+                    Cards.FromName("Alley Armorsmith"),
+                    Cards.FromName("Alley Armorsmith"),
+                },
+                FillDecks = false,
+                Shuffle = false
+
             });
             game.StartGame();
             game.Player1.BaseMana = 10;
             game.Player2.BaseMana = 10;
-            game.CurrentPlayer.Hero.Damage = 10;
-            var testCard = Generic.DrawCard(game.CurrentPlayer, Cards.FromName("Ivory Knight"));
-            game.Process(PlayCardTask.Spell(game.CurrentPlayer, testCard));
-            var spell = game.IdEntityDic[game.CurrentPlayer.Choice.Choices[0]];
-            game.Process(ChooseTask.Pick(game.CurrentPlayer, game.CurrentPlayer.Choice.Choices[0]));
 
+            var testCard = Generic.DrawCard(game.CurrentPlayer, Cards.FromName("Alarm-o-Bot"));
+            game.Process(PlayCardTask.Minion(game.CurrentPlayer, testCard));
+            game.Process(EndTurnTask.Any(game.CurrentPlayer));
+            game.Process(EndTurnTask.Any(game.CurrentPlayer));
             ShowLog(game, LogLevel.VERBOSE);
 
             Console.WriteLine(game.CurrentPlayer.Board.FullPrint());


### PR DESCRIPTION
Reverts HearthSim/SabberStone#21

the way you implemented it it will not work ...
because a task is never executed in the instanciated version it is on the card .... it is cloned ... always before it get s executed ...

so this is always called on each Task ...before it is executed 

        public override ISimpleTask Clone()
        {
            var clone = new HealTask(Amount, Type);
            clone.Copy(this);
            return clone;
        }

which the will always call the constructor for ... Sort = HealType.Heal;