### PR TITLE
Setup heroes from Hero Card (if set)

### DIFF
--- a/SabberStoneCore/src/Model/Game.cs
+++ b/SabberStoneCore/src/Model/Game.cs
@@ -239,9 +239,10 @@ namespace SabberStoneCore.Model
 
 			if (setupHeroes)
 			{
-				_players[0].AddHeroAndPower(Cards.HeroCard(gameConfig.Player1HeroClass));
+				_players[0].AddHeroAndPower(gameConfig.Player1HeroCard ?? Cards.HeroCard(gameConfig.Player1HeroClass));
 				_players[0].BaseClass = _players[0].HeroClass;
-				_players[1].AddHeroAndPower(Cards.HeroCard(gameConfig.Player2HeroClass));
+
+				_players[1].AddHeroAndPower(gameConfig.Player2HeroCard ?? Cards.HeroCard(gameConfig.Player2HeroClass));
 				_players[1].BaseClass = _players[1].HeroClass;
 			}
 


### PR DESCRIPTION
Load player and opponent Hero data from their Hero card, if it is set, otherwise load Hero data based on class.