### PR TITLE
Fix for Adapt cards in Kiln

### DIFF
--- a/SabberStoneCore/src/Actions/Choose.cs
+++ b/SabberStoneCore/src/Actions/Choose.cs
@@ -83,6 +83,21 @@ namespace SabberStoneCore.Actions
 							IPlayable target = c.Game.IdEntityDic[p];
 							playable.Enchantments.ForEach(t => t.Activate(c, playable, target));
 						});
+						// Need to move the chosen adaptation to the Graveyard
+						c.Game.TaskQueue.Enqueue(new MoveToGraveYard(EntityType.SOURCE)
+						{
+							Game = c.Game,
+							Controller = c,
+							Source = playable,
+							Target = playable
+						});
+						// Send metadata to the client to hide the card
+						c.Game.PowerHistory.Add(new PowerHistoryMetaData
+						{
+							Type = MetaDataType.SHOW_BIG_CARD,
+							Data = 2,
+							Info = new List<int> { choice }
+						});
 						break;
 
 					case ChoiceAction.TRACKING:

--- a/SabberStoneCore/src/Kettle/PowerHistory.cs
+++ b/SabberStoneCore/src/Kettle/PowerHistory.cs
@@ -330,6 +330,27 @@ namespace SabberStoneCore.Kettle
 		}
 	}
 
+	//message PowerHistoryMetaData
+	//{
+	//    repeated int32 info = 2;
+	//    HistoryMeta.Type type = 3;
+	//    int32 data = 4;
+	//}
+	public class PowerHistoryMetaData : IPowerHistoryEntry
+	{
+		public PowerType PowerType => PowerType.META_DATA;
+		public MetaDataType Type { get; set; }
+		public int Data { get; set; }
+		public List<int> Info { get; set; }
+
+		public string Print()
+		{
+			var str = new StringBuilder();
+			str.AppendLine($"{PowerType} Type={Type} Data={Data} Info={string.Join(", ", Info)}");
+			return str.ToString();
+		}
+	}
+
 	//message PowerHistoryEntity
 	//{
 	//    required int32 entity = 1;


### PR DESCRIPTION
This PR adds the PowerHistoryMetaData type to SabberStone, and slightly modifies the simulator's behavior when choosing an entity for Adapt, according to observations from the live servers - the selected card will be sent to the graveyard, and the correct MetaData will be generated. Technically the LAST_AFFECTED_BY should also be set to the EntityId of the Adapt card that was played, but I didn't want to make more changes than were necessary.

I've uploaded the log showing this behaviour from the live servers:
https://pastebin.com/raw/r1i71KH6